### PR TITLE
Increase I2C buffer size from 32 to 512 bytes

### DIFF
--- a/src/i2c_port.c
+++ b/src/i2c_port.c
@@ -131,7 +131,7 @@ static void i2c_handle_request(const char *req, void *cookie)
             addr > 127)
         errx(EXIT_FAILURE, "addr: min=0, max=127");
 
-    char resp[256];
+    char resp[1024];
     int resp_index = sizeof(uint16_t); // Space for payload size
     ei_encode_version(resp, &resp_index);
     if (strcmp(cmd, "read") == 0) {

--- a/src/i2c_port.c
+++ b/src/i2c_port.c
@@ -131,7 +131,7 @@ static void i2c_handle_request(const char *req, void *cookie)
             addr > 127)
         errx(EXIT_FAILURE, "addr: min=0, max=127");
 
-    char resp[1024];
+    char resp[1024]; // Must be larger than I2C_BUFFER_MAX
     int resp_index = sizeof(uint16_t); // Space for payload size
     ei_encode_version(resp, &resp_index);
     if (strcmp(cmd, "read") == 0) {

--- a/src/i2c_port.c
+++ b/src/i2c_port.c
@@ -41,6 +41,8 @@
 #define debug(...)
 #endif
 
+#define I2C_BUFFER_MAX I2C_SMBUS_BLOCK_MAX
+
 struct i2c_info
 {
     int fd;
@@ -137,10 +139,10 @@ static void i2c_handle_request(const char *req, void *cookie)
         long int len;
         if (ei_decode_long(req, &req_index, &len) < 0 ||
                 len < 1 ||
-                len > I2C_SMBUS_BLOCK_MAX)
-            errx(EXIT_FAILURE, "read amount: min=1, max=%d", I2C_SMBUS_BLOCK_MAX);
+                len > I2C_BUFFER_MAX)
+            errx(EXIT_FAILURE, "read amount: min=1, max=%d", I2C_BUFFER_MAX);
 
-        char data[I2C_SMBUS_BLOCK_MAX];
+        char data[I2C_BUFFER_MAX];
 
         if (i2c_transfer(i2c, addr, 0, 0, data, len))
             ei_encode_binary(resp, &resp_index, data,len);
@@ -150,16 +152,16 @@ static void i2c_handle_request(const char *req, void *cookie)
             ei_encode_atom(resp, &resp_index, "i2c_read_failed");
         }
     } else if (strcmp(cmd, "write") == 0) {
-        char data[I2C_SMBUS_BLOCK_MAX];
+        char data[I2C_BUFFER_MAX];
         int len;
         int type;
         long llen;
         if (ei_get_type(req, &req_index, &type, &len) < 0 ||
                 type != ERL_BINARY_EXT ||
                 len < 1 ||
-                len > I2C_SMBUS_BLOCK_MAX ||
+                len > I2C_BUFFER_MAX ||
                 ei_decode_binary(req, &req_index, &data, &llen) < 0)
-            errx(EXIT_FAILURE, "write: need a binary between 1 and %d bytes", I2C_SMBUS_BLOCK_MAX);
+            errx(EXIT_FAILURE, "write: need a binary between 1 and %d bytes", I2C_BUFFER_MAX);
 
         if (i2c_transfer(i2c, addr, data, len, 0, 0))
             ei_encode_atom(resp, &resp_index, "ok");
@@ -169,8 +171,8 @@ static void i2c_handle_request(const char *req, void *cookie)
             ei_encode_atom(resp, &resp_index, "i2c_write_failed");
         }
     } else if (strcmp(cmd, "wrrd") == 0) {
-        char write_data[I2C_SMBUS_BLOCK_MAX];
-        char read_data[I2C_SMBUS_BLOCK_MAX];
+        char write_data[I2C_BUFFER_MAX];
+        char read_data[I2C_BUFFER_MAX];
         int write_len;
         long int read_len;
         int type;
@@ -183,13 +185,13 @@ static void i2c_handle_request(const char *req, void *cookie)
         if (ei_get_type(req, &req_index, &type, &write_len) < 0 ||
                 type != ERL_BINARY_EXT ||
                 write_len < 1 ||
-                write_len > I2C_SMBUS_BLOCK_MAX ||
+                write_len > I2C_BUFFER_MAX ||
                 ei_decode_binary(req, &req_index, &write_data, &llen) < 0)
-            errx(EXIT_FAILURE, "wrrd: need a binary between 1 and %d bytes", I2C_SMBUS_BLOCK_MAX);
+            errx(EXIT_FAILURE, "wrrd: need a binary between 1 and %d bytes", I2C_BUFFER_MAX);
         if (ei_decode_long(req, &req_index, &read_len) < 0 ||
                 read_len < 1 ||
-                read_len > I2C_SMBUS_BLOCK_MAX)
-            errx(EXIT_FAILURE, "wrrd: read amount: min=1, max=%d", I2C_SMBUS_BLOCK_MAX);
+                read_len > I2C_BUFFER_MAX)
+            errx(EXIT_FAILURE, "wrrd: read amount: min=1, max=%d", I2C_BUFFER_MAX);
 
         if (i2c_transfer(i2c, addr, write_data, write_len, read_data, read_len))
             ei_encode_binary(resp, &resp_index, read_data, read_len);

--- a/src/i2c_port.c
+++ b/src/i2c_port.c
@@ -41,7 +41,7 @@
 #define debug(...)
 #endif
 
-#define I2C_BUFFER_MAX I2C_SMBUS_BLOCK_MAX
+#define I2C_BUFFER_MAX 512
 
 struct i2c_info
 {


### PR DESCRIPTION
As discussed in #20.
