### PR TITLE
Describe initial message sent after Gpio.set_int

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ If you'd like to get a message when the button is pressed or released, call the
     {:gpio_interrupt, 17, :rising}
     {:gpio_interrupt, 17, :falling}
     :ok
+    
+Note that after calling `set_int`, the calling process will receive an initial message with the state of the pin.
+This prevents the race condition between getting the initial state of the pin and turning on interrupts. Without it, you could get the state of the pin, it could change states, and then you could start waiting on it for interrupts. If that happened, you would be out of sync.
 
 ## SPI
 


### PR DESCRIPTION
Thanks to @fhunleth for explaining this in the #nerves Slack channel.

Related to https://github.com/fhunleth/elixir_ale/issues/24 which may change this behavior.
