### PR TITLE
Make detect_devices/1 easier to run and add device name helpers

### DIFF
--- a/lib/elixir_ale/i2c.ex
+++ b/lib/elixir_ale/i2c.ex
@@ -101,6 +101,23 @@ defmodule ElixirALE.I2C do
   end
 
   @doc """
+  Return a list of available I2C bus device names.  If nothing is returned,
+  it's possible that the kernel driver for that I2C bus is not enabled or the
+  kernel's device tree is not configured. On Raspbian, run `raspi-config` and
+  look in the advanced options.
+
+  ```
+  iex> ElixirALE.I2C.device_names
+  ["i2c-1"]
+  ```
+  """
+  @spec device_names() :: [binary]
+  def device_names() do
+    Path.wildcard("/dev/i2c-*")
+    |> Enum.map(fn(p) -> String.replace_prefix(p, "/dev/", "") end)
+  end
+
+  @doc """
   Scan the I2C bus for devices by performing a read at each device address
   and returning a list of device addresses that respond.
 

--- a/lib/elixir_ale/spi.ex
+++ b/lib/elixir_ale/spi.ex
@@ -19,6 +19,23 @@ defmodule ElixirALE.SPI do
 
   # Public API
   @doc """
+  Return a list of available SPI bus device names.  If nothing is returned,
+  it's possible that the kernel driver for that SPI bus is not enabled or the
+  kernel's device tree is not configured. On Raspbian, run `raspi-config` and
+  look in the advanced options.
+
+  ```
+  iex> ElixirALE.SPI.device_names
+  ["spidev0.0", "spidev0.1"]
+  ```
+  """
+  @spec device_names() :: [binary]
+  def device_names() do
+    Path.wildcard("/dev/spidev*")
+    |> Enum.map(fn(p) -> String.replace_prefix(p, "/dev/", "") end)
+  end
+
+  @doc """
   Start and link a SPI GenServer.
 
   SPI bus options include:

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule ElixirAle.Mixfile do
+defmodule ElixirALE.Mixfile do
   use Mix.Project
 
   def project do

--- a/test/elixir_ale_test.exs
+++ b/test/elixir_ale_test.exs
@@ -1,4 +1,4 @@
-defmodule ElixirAleTest do
+defmodule ElixirALETest do
   use ExUnit.Case
 
   test "the truth" do


### PR DESCRIPTION
This change makes it easier to get started with ElixirALE by adding helpers to list device names and updating the I2C device detection to not require a pid. 

Here's the old way of getting started with I2C:
```
iex> ls "/dev"
# Look for i2c in the output
iex> {:ok, pid} = ElixirALE.I2C.start_link("i2c-1")
iex> ElixirALE.I2C.detect_devices(pid)
[4]
```
You can now do this:

```
iex> ElixirALE.I2C.device_names
["i2c-1"]
iex> ElixirALE.I2C.detect_devices("i2c-1")
[4]
```
SPI has also been updated with a `device_names/0` helper.
