### PR TITLE
Add `:none` to typespec for interrupt direction

### DIFF
--- a/lib/elixir_ale/gpio.ex
+++ b/lib/elixir_ale/gpio.ex
@@ -12,7 +12,7 @@ defmodule ElixirALE.GPIO do
   end
 
   @type pin_direction :: :input | :output
-  @type int_direction :: :rising | :falling | :both
+  @type int_direction :: :rising | :falling | :both | :none
 
   # Public API
   @doc """


### PR DESCRIPTION
Using `:none` appears to be the preferred means of unsetting the
interrupt callback for a pin, but using it and running `mix dialyzer` on
a project results in the following error:

```
The call 'Elixir.ElixirALE.GPIO':set_int(interrupt_pid@1::any(),'none') breaks the contract (pid(),int_direction()) -> 'ok' | {'error',term()}
```