### PR TITLE
Bumping SPI_TRANSFER_MAX from 256 to 4096

### DIFF
--- a/src/spi_port.c
+++ b/src/spi_port.c
@@ -47,7 +47,7 @@
 #endif
 
 // Max SPI transfer size that we support
-#define SPI_TRANSFER_MAX 256
+#define SPI_TRANSFER_MAX 4096
 
 struct spi_info
 {


### PR DESCRIPTION
Hi, this PR just updates the size of the SPI_TRANSFER_MAX buffer from 256 bytes to 4096 bytes. This brings it into parity with the python [py-spidev library](https://github.com/doceme/py-spidev/blob/master/spidev_module.c#L31), which is widely used for Raspberry PI projects, and should be safe as [the actual length parameter in the kernel](https://github.com/torvalds/linux/blob/v4.9/include/uapi/linux/spi/spidev.h#L93) is 32 bits.

I needed this to interface with this [little PI hardware board](https://github.com/pimoroni/unicorn-hat-hd), which you control by transferring 768 bytes at a time over SPI. I verified it works by compiling my updated fork on the PI and then running this:

```
pi@blinky2:~/elixir_ale $ iex -S mix
Erlang/OTP 19 [erts-8.2.1] [source] [smp:4:4] [async-threads:10] [kernel-poll:false]

make: Nothing to be done for 'all'.
Interactive Elixir (1.4.5) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> alias ElixirALE.SPI
ElixirALE.SPI
iex(2)> {:ok, pid} = SPI.start_link("spidev0.0", [speed_hz: 9000000])
{:ok, #PID<0.136.0>}
iex(3)> d = Enum.reduce(1 .. (16 * 16 * 3), << 0x72 >>, fn(x, acc) -> << acc :: binary >> <> << :rand.uniform(256) - 1 :: size(8) >> end)
<<120, 236, 137, 118, 47, 80, 204, 33, 46, 158, 229, 2, 114, 207, 36, 89, 104,
  70, 94, 195, 137, 250, 49, 234, 206, 208, 139, 134, 248, 116, 142, 26, 150,
  165, 239, 133, 178, 81, 221, 76, 173, 60, 204, 129, 19, 155, 147, 41, 163, 28,
  ...>>
iex(4)> SPI.transfer(pid, d)
<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>
```

Everything seems to be working fine, and I can't see any reason not bump up the limit (save increased stack space during SPI transfers).