### PR TITLE
SPI GenServer uses handle_info instead of receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v1.0.3-dev
 
+  * Bug fixes
+    * SPI GenServer no longer uses `receive` block to read data from `Port`.
+      The `receive` block was intercepting GenServer calls, and thus concurrent
+      reads to SPI would crash the GenServer.
+    
 ## v1.0.2
 
   * Bug fixes


### PR DESCRIPTION
Solves the concurrent reads reported in #53 