### PR TITLE
Allows concurrent calls to SPI

### DIFF
--- a/lib/elixir_ale/spi.ex
+++ b/lib/elixir_ale/spi.ex
@@ -1,9 +1,11 @@
 defmodule ElixirALE.SPI.Port.Behaviour do
+  @moduledoc "A behaviour for testing SPI"
   @callback open(String.t, list) :: port
   @callback transfer(port, binary) :: :ok
 end
 
 defmodule ElixirALE.SPI.Port do
+  @moduledoc "The default implementation for ElixirALE.SPI.Port.Behaviour"
   @behaviour ElixirALE.SPI.Port.Behaviour
 
   def open(executable, options) do

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,8 @@ defmodule ElixirALE.Mixfile do
   defp deps do
     [
       {:elixir_make, "~> 0.4", runtime: false},
-      {:ex_doc, "~> 0.11", only: :dev}
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:mox, "~> 0.3.1", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mox": {:hex, :mox, "0.3.1", "2ab1dce006387a91fbe1e727ba468d3e0691eacfd4e2fc7308d53676ec335c46", [:mix], [], "hexpm"},
 }

--- a/test/elixir_ale/spi_test.exs
+++ b/test/elixir_ale/spi_test.exs
@@ -8,7 +8,7 @@ defmodule ElixirALE.SPI.Test do
     Application.put_env(:elixir_ale, :spi_port, MockSPIPort)
 
     port = make_ref()
-    stub(MockSPIPort, :open, fn(_, _)-> port end)
+    stub(MockSPIPort, :open, fn(_, _) -> port end)
     set_mox_global()
     {:ok, pid} = start_supervised Subject
     {:ok, subject: pid, port: port}
@@ -17,21 +17,21 @@ defmodule ElixirALE.SPI.Test do
   test "calling the same port twice",
   %{subject: subject, port: port} do
     stub(MockSPIPort, :transfer, fn
-      (^port, <<"one">>)->
+      (^port, <<"one">>) ->
         Process.send_after(subject,
                            {:foo, {:data, :erlang.term_to_binary(:response_one)}},
                            100)
-      (^port, <<"two">>)->
+      (^port, <<"two">>) ->
         send(subject,
              {:foo, {:data, :erlang.term_to_binary(:response_two)}}
         )
     end)
 
-    transfer_one = Task.async(fn->
+    transfer_one = Task.async(fn ->
       Subject.transfer(subject, <<"one">>)
     end)
 
-    transfer_two = Task.async(fn->
+    transfer_two = Task.async(fn ->
       Subject.transfer(subject, <<"two">>)
     end)
 

--- a/test/elixir_ale/spi_test.exs
+++ b/test/elixir_ale/spi_test.exs
@@ -1,0 +1,41 @@
+defmodule ElixirALE.SPI.Test do
+  use ExUnit.Case, async: false
+  alias ElixirALE.SPI, as: Subject
+  import Mox
+
+  setup do
+    defmock(MockSPIPort, for: ElixirALE.SPI.Port.Behaviour)
+    Application.put_env(:elixir_ale, :spi_port, MockSPIPort)
+
+    port = make_ref()
+    stub(MockSPIPort, :open, fn(_, _)-> port end)
+    set_mox_global()
+    {:ok, pid} = start_supervised Subject
+    {:ok, subject: pid, port: port}
+  end
+
+  test "calling the same port twice",
+  %{subject: subject, port: port} do
+    stub(MockSPIPort, :transfer, fn
+      (^port, <<"one">>)->
+        Process.send_after(subject,
+                           {:foo, {:data, :erlang.term_to_binary(:response_one)}},
+                           100)
+      (^port, <<"two">>)->
+        send(subject,
+             {:foo, {:data, :erlang.term_to_binary(:response_two)}}
+        )
+    end)
+
+    transfer_one = Task.async(fn->
+      Subject.transfer(subject, <<"one">>)
+    end)
+
+    transfer_two = Task.async(fn->
+      Subject.transfer(subject, <<"two">>)
+    end)
+
+    assert Task.await(transfer_one) == :response_one
+    assert Task.await(transfer_two) == :response_two
+  end
+end


### PR DESCRIPTION
When sending two calls to one SPI connection, the connection would
confuse the second call with the response to the first. The bug came
about because the `receive` block had a catch-all for errors, but that
was catching the new incoming request. Removing the catch-all allows
both requests to process.

closes #55 and #53 

Amos King @adkron <amos@binarynoggin.com>