### PR TITLE
Add `pin/1` to GPIO for getting the linked GPIO PIN number

### DIFF
--- a/lib/elixir_ale/gpio.ex
+++ b/lib/elixir_ale/gpio.ex
@@ -32,6 +32,12 @@ defmodule ElixirALE.GPIO do
   end
 
   @doc """
+  Helper method for reading the pin number that the GPIO GenServer
+  is linked to.
+  """
+  def pin(pid), do: GenServer.call(pid, :pin)
+
+  @doc """
   Free the resources associated with pin and stop the GenServer.
   """
   @spec release(pid) :: :ok
@@ -106,6 +112,10 @@ defmodule ElixirALE.GPIO do
       {:error, reason} -> {:stop, reason}
       error -> error
     end
+  end
+
+  def handle_call(:pin, _from, state) do
+    {:reply, state.pin, state}
   end
 
   def handle_call(:read, _from, state) do


### PR DESCRIPTION
This is just a really simple helper function to get the `pin` that is associated with the GPIO GenServer process.

Lately I've found myself with a list of GenServer processes wonder what pin it is using so thought I'd add here in case any other folks fall in the same predicament 😆