### PR TITLE
Issue 62 : GPIO spurious edge notifications

### DIFF
--- a/src/gpio_port.c
+++ b/src/gpio_port.c
@@ -52,6 +52,7 @@ struct gpio {
     enum gpio_state state;
     int fd;
     int pin_number;
+    char edge[8];
 };
 
 /**
@@ -197,6 +198,8 @@ int gpio_set_int(struct gpio *pin, const char *mode)
     sprintf(path, "/sys/class/gpio/gpio%d/edge", pin->pin_number);
     if (!sysfs_write_file(path, mode))
         return -1;
+    (void)strncpy(pin->edge, mode, sizeof(pin->edge)); /* Remember edge */
+    pin->edge[sizeof(pin->edge) - 1] = '\0';    /* Forcefully terminate */
 
     if (strcmp(mode, "none") == 0)
         pin->state = GPIO_INPUT;
@@ -222,7 +225,10 @@ void gpio_process(struct gpio *pin)
     ei_encode_version(resp, &resp_index);
     ei_encode_tuple_header(resp, &resp_index, 2);
     ei_encode_atom(resp, &resp_index, "gpio_interrupt");
-    ei_encode_atom(resp, &resp_index, value ? "rising" : "falling");
+    if (strcmp(pin->edge, "both") == 0)
+        ei_encode_atom(resp, &resp_index, value ? "rising" : "falling");
+    else
+        ei_encode_atom(resp, &resp_index, pin->edge);
     erlcmd_send(resp, resp_index);
 }
 
@@ -263,7 +269,7 @@ void gpio_handle_request(const char *req, void *cookie)
         long value;
         if (ei_decode_long(req, &req_index, &value) < 0)
             errx(EXIT_FAILURE, "write: didn't get value to write");
-        debug("write %d", value);
+        debug("write %d", (int)value);
         if (gpio_write(pin, value))
             ei_encode_atom(resp, &resp_index, "ok");
         else {
@@ -275,7 +281,7 @@ void gpio_handle_request(const char *req, void *cookie)
         char mode[32];
         if (ei_decode_atom(req, &req_index, mode) < 0)
             errx(EXIT_FAILURE, "set_int: didn't get value");
-        debug("write %s", mode);
+        debug("mode %s", mode);
 
         if (gpio_set_int(pin, mode))
             ei_encode_atom(resp, &resp_index, "ok");

--- a/src/gpio_port.c
+++ b/src/gpio_port.c
@@ -199,7 +199,6 @@ int gpio_set_int(struct gpio *pin, const char *mode)
     if (!sysfs_write_file(path, mode))
         return -1;
     (void)strncpy(pin->edge, mode, sizeof(pin->edge)); /* Remember edge */
-    pin->edge[sizeof(pin->edge) - 1] = '\0';    /* Forcefully terminate */
 
     if (strcmp(mode, "none") == 0)
         pin->state = GPIO_INPUT;


### PR DESCRIPTION
Basic fix has been tested on RPi3B+ under Nerves 1.3 on Nerves_system_rpi3 1.5.1

As mentioned in issue comments, for edge direction `:both`, user code will still need to debounce / interpret the message signals to meet particular solution needs.
